### PR TITLE
Critical Fix: Copy files using SubprocessLauncher instead of the GFile API

### DIFF
--- a/io.github.diegoivan.pdf_metadata_editor.json
+++ b/io.github.diegoivan.pdf_metadata_editor.json
@@ -52,10 +52,9 @@
             ],
             "sources" : [
                 {
-                    "url" : "https://gitlab.freedesktop.org/poppler/poppler.git",
-                    "type" : "git",
-                    "tag" : "poppler-23.01.0",
-                    "commit" : "4259ff0c2067d302f97d87221a442eec8e88d45c"
+                    "url" : "https://poppler.freedesktop.org/poppler-24.08.0.tar.xz",
+                    "type" : "archive",
+                    "sha256" : "97453fbddf0c9a9eafa0ea45ac710d3d49bcf23a62e864585385d3c0b4403174"
                 }
             ]
         },

--- a/src/Document.vala
+++ b/src/Document.vala
@@ -451,7 +451,9 @@ public class PaperClip.Document : Object {
                                                    "copies");
 
         int res = DirUtils.create_with_parents (destination_path, 0777);
-        return_if_fail (res > -1);
+        if (res < 0) {
+            throw new IOError.FAILED (@"Could not create $destination_path");
+        }
 
         string destination_file = Path.build_filename (destination_path,
                                                        "%s".printf (original_file.get_basename ()));

--- a/src/Document.vala
+++ b/src/Document.vala
@@ -445,11 +445,11 @@ public class PaperClip.Document : Object {
     }
 
     private async File create_copy_from_original () throws Error {
+        var launcher = new SubprocessLauncher (NONE);
         unowned string tmp_dir = Environment.get_tmp_dir ();
         string destination_path = Path.build_path (Path.DIR_SEPARATOR_S,
                                                    tmp_dir,
                                                    "copies");
-
         int res = DirUtils.create_with_parents (destination_path, 0777);
         if (res < 0) {
             throw new IOError.FAILED (@"Could not create $destination_path");
@@ -458,13 +458,14 @@ public class PaperClip.Document : Object {
         string destination_file = Path.build_filename (destination_path,
                                                        "%s".printf (original_file.get_basename ()));
 
-        var copy_file = File.new_for_path (destination_file);
-        FileCopyFlags flags = NOFOLLOW_SYMLINKS | OVERWRITE | ALL_METADATA;
-
-        bool success = yield original_file.copy_async (copy_file, flags);
+        Subprocess copy_process = launcher.spawn("cp", original_file.get_path(), destination_path);
+        bool success = yield copy_process.wait_async ();
         if (!success) {
-            critical ("Copy Unsuccessful");
+            critical ("Processed failed");
         }
+
+
+        var copy_file = File.new_for_path (destination_file);
 
         return copy_file;
     }


### PR DESCRIPTION
The GFile copy API seems to be broken with a newer version of the xdg-desktop-portal, so we'll be using this temporarily. This fix will be backported for the v5.5 release.