### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/io.github.diegoivan.pdf_metadata_editor.desktop.in
+++ b/data/io.github.diegoivan.pdf_metadata_editor.desktop.in
@@ -2,6 +2,7 @@
 Name=Paper Clip
 Exec=pdf-metadata-editor %U
 Icon=io.github.diegoivan.pdf_metadata_editor
+DBusActivatable=true
 Terminal=false
 Type=Application
 Keywords=PDF;Metadata;Editor;

--- a/data/io.github.diegoivan.pdf_metadata_editor.service.in
+++ b/data/io.github.diegoivan.pdf_metadata_editor.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=io.github.diegoivan.pdf_metadata_editor
+Exec=@bindir@/pdf-metadata-editor --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -40,4 +40,13 @@ if compile_schemas.found()
        args: ['--strict', '--dry-run', meson.current_source_dir()])
 endif
 
+service_conf = configuration_data()
+service_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+configure_file(
+        input: 'io.github.diegoivan.pdf_metadata_editor.service.in',
+       output: 'io.github.diegoivan.pdf_metadata_editor.service',
+configuration: service_conf,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1/services')
+)
+
 subdir('icons')


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html