### PR TITLE
appstream: Fix app id

### DIFF
--- a/data/io.github.diegoivan.pdf_metadata_editor.metainfo.xml.in
+++ b/data/io.github.diegoivan.pdf_metadata_editor.metainfo.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>io.github.diegoivan.pdf_metadata_editor.desktop</id>
+  <id>io.github.diegoivan.pdf_metadata_editor</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
 


### PR DESCRIPTION
The `.desktop` extension is not valid for app ids and [causing issues](https://github.com/flathub/flathub/issues/4222#issuecomment-2018677522).